### PR TITLE
Publish patterns-ts 1.0.0

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,6 +77,10 @@ jobs:
         run: |
           cd ${{ matrix.package }}
           npm run build
+      
+      - name: Add license
+        if: matrix.changed == true
+        run: cp LICENSE ${{ matrix.package }}/
 
       - name: Publish package
         if: matrix.changed == true

--- a/patterns-ts/.npmignore
+++ b/patterns-ts/.npmignore
@@ -16,6 +16,9 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 # TypeScript cache
 *.tsbuildinfo
 
+# ESLint
+eslint.config.js
+
 # Optional eslint cache
 .eslintcache
 

--- a/patterns-ts/package-lock.json
+++ b/patterns-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patternsoflife/patterns",
-      "version": "1.0.0-alpha.7",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^19.1.8",

--- a/patterns-ts/package.json
+++ b/patterns-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0",
   "description": "Problem-sustaining patterns in TypeScript",
   "type": "module",
   "main": "./lib/index.js",


### PR DESCRIPTION
Resolves #15 

Notes:

- This PR only publishes the `patterns` package, but not the `patterns-cli` package. The reason is that I cannot install `patterns-1.0.0` into `patterns-cli` yet which means that I cannot update the `package-lock.json` from `patterns-cli` yet, and even though `package-lock.json` is not needed for publishing, I do prefer to check corresponding changes to `package.json` and `package-lock.json` into the same commit. I am sure there is a better way to handle this, but right now I will just make separate pull requests.
- The ESLint configuration is now ignored for publishing
- The license is now added by means of a deployment step