### PR TITLE
Fix bidirectional arrow rendering in SVG files

### DIFF
--- a/patterns-ts/package-lock.json
+++ b/patterns-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patternsoflife/patterns",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^19.1.8",

--- a/patterns-ts/package.json
+++ b/patterns-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Problem-sustaining patterns in TypeScript",
   "type": "module",
   "main": "./lib/index.js",

--- a/patterns-ts/src/visual/psvg/edges.tsx
+++ b/patterns-ts/src/visual/psvg/edges.tsx
@@ -31,8 +31,9 @@ const getEdgePosition = (node: PatternNode, intersectionPoint: { x: number, y: n
 };
 
 
-export const EdgeSVG = ({ edge }: {
+export const EdgeSVG = ({ edge, isBidirectional = false }: {
   edge: PatternEdge,
+  isBidirectional?: boolean,
 }) => {
   const [source, target] = edge.nodes;
 
@@ -52,6 +53,11 @@ export const EdgeSVG = ({ edge }: {
   });
 
   return (
-    <path d={d} className='p2s_arrowpath' markerEnd="url(#p2s_arrowmarker)" />
+    <path
+      d={d}
+      className='p2s_arrowpath'
+      markerEnd="url(#p2s_arrowmarker_end)"
+      {...(isBidirectional && { markerStart: 'url(#p2s_arrowmarker_start)' })}
+    />
   );
 };

--- a/patterns-ts/src/visual/psvg/kit.tsx
+++ b/patterns-ts/src/visual/psvg/kit.tsx
@@ -187,7 +187,8 @@ export const SvgDocument = ({ pos, size, children }: {
         <symbol id='p2s_thought' viewBox='75 50 530 350'>
           <path fill={COLOR.CONTEXT_CAT[1].color} d={THOUGHT_PATH_DATA} />
         </symbol>
-        <ArrowMarker id='p2s_arrowmarker' className='p2s_arrowhead' cairo />
+        <ArrowMarker id='p2s_arrowmarker_end' className='p2s_arrowhead' cairo />
+        <ArrowMarker id='p2s_arrowmarker_start' className='p2s_arrowhead' cairo orient='auto-start-reverse' />
       </defs>
       <rect x={pos[0]} y={pos[1]} width={size[0]} height={size[1]} fill={COLOR.BG_AIR} />
       {children}

--- a/patterns-ts/src/visual/psvg/patternsvg.tsx
+++ b/patterns-ts/src/visual/psvg/patternsvg.tsx
@@ -53,15 +53,13 @@ export const PatternSVG = ({ pattern, config }: {
         size={[width, height]}
       >
         {
-          Array.from(edgeMap.entries(), ([key, { edge, isBidirectional }]) => {
-            return (
-              <EdgeSVG
-                key={key}
-                edge={edge}
-                isBidirectional={isBidirectional}
-              />
-            );
-          })
+          Array.from(edgeMap.entries(), ([key, { edge, isBidirectional }]) => (
+            <EdgeSVG
+              key={key}
+              edge={edge}
+              isBidirectional={isBidirectional}
+            />
+          ))
         }
         {
           pattern.nodes.map(node => (

--- a/patterns-ts/src/visual/psvg/patternsvg.tsx
+++ b/patterns-ts/src/visual/psvg/patternsvg.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
-import { Pattern } from '../../core.js';
+import { Pattern, PatternEdge } from '../../core.js';
 import { PatternSVGConfig, SvgContext } from './config.js';
 import { SvgDocument } from './kit.js';
 import { NodeSVG } from './nodes.js';
@@ -31,6 +31,21 @@ export const PatternSVG = ({ pattern, config }: {
   const width = xEnd - xStart;
   const height = yEnd - yStart;
 
+  const edgeMap = new Map<string, { edge: PatternEdge, isBidirectional: boolean }>();
+
+  for (const edge of pattern.edges) {
+    const [s, t] = edge.nodes.map(node => node.crossRevisionId);
+    const key = `${s}-${t}`;
+    const reverseKey = `${t}-${s}`;
+
+    if (edgeMap.has(reverseKey)) {
+      edgeMap.set(reverseKey, { edge, isBidirectional: true });
+    } else {
+      edgeMap.set(key, { edge, isBidirectional: false });
+    }
+  }
+
+
   return (
     <SvgContext value={config}>
       <SvgDocument
@@ -38,9 +53,15 @@ export const PatternSVG = ({ pattern, config }: {
         size={[width, height]}
       >
         {
-          pattern.edges.map(edge => (
-            <EdgeSVG key={edge.crossRevisionId} edge={edge} />
-          ))
+          Array.from(edgeMap.entries(), ([key, { edge, isBidirectional }]) => {
+            return (
+              <EdgeSVG
+                key={key}
+                edge={edge}
+                isBidirectional={isBidirectional}
+              />
+            );
+          })
         }
         {
           pattern.nodes.map(node => (


### PR DESCRIPTION
Resolves #38 

Adds a check for bidirectional arrows to prevent rendering a bidirectional arrow as two unidirectional arrows.