### PR TITLE
Adds an optional color prop to arrow markers

### DIFF
--- a/patterns-ts/package-lock.json
+++ b/patterns-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@patternsoflife/patterns",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/react": "^19.1.8",

--- a/patterns-ts/package.json
+++ b/patterns-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@patternsoflife/patterns",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Problem-sustaining patterns in TypeScript",
   "type": "module",
   "main": "./lib/index.js",

--- a/patterns-ts/src/visual/skin.tsx
+++ b/patterns-ts/src/visual/skin.tsx
@@ -58,18 +58,19 @@ const Marker = ({ id, className, orient, children }) => (
 );
 
 
-export const ArrowMarker = ({ id, className = '', selected = false, cairo = false, orient = 'auto' }: {
+export const ArrowMarker = ({ id, className = '', selected = false, cairo = false, orient = 'auto', color = COLOR.ARROW_MARKER }: {
   id: string,
   className?: string,
   selected?: boolean,
   cairo?: boolean,
   orient?: string,
+  color?: string,
 }) => (
   <Marker id={id} className={className || "react-flow__arrowhead"} orient={orient}>
     <polyline
       style={{
         strokeWidth: 1.5,
-        stroke: selected ? COLOR.ARROW_SELECTED : COLOR.ARROW_MARKER,
+        stroke: selected ? COLOR.ARROW_SELECTED : color,
         fill: 'none',
       }}
       strokeLinecap="round"

--- a/patterns-ts/src/visual/skin.tsx
+++ b/patterns-ts/src/visual/skin.tsx
@@ -29,6 +29,7 @@ export const COLOR = {
   ARROW: '#808080',
   ARROW_MARKER: '#909090',
   ARROW_SELECTED: '#008cff',
+  ARROW_HIGHLIGHTED: '#ee82ee',
   BG_AIR: '#f3faff',
   CARD: '#ffffff',
   CONTEXT_CAT: {
@@ -58,19 +59,19 @@ const Marker = ({ id, className, orient, children }) => (
 );
 
 
-export const ArrowMarker = ({ id, className = '', selected = false, cairo = false, orient = 'auto', color = COLOR.ARROW_MARKER }: {
+export const ArrowMarker = ({ id, className = '', selected = false, cairo = false, orient = 'auto', highlighted = false }: {
   id: string,
   className?: string,
   selected?: boolean,
   cairo?: boolean,
   orient?: string,
-  color?: string,
+  highlighted?: boolean,
 }) => (
   <Marker id={id} className={className || "react-flow__arrowhead"} orient={orient}>
     <polyline
       style={{
         strokeWidth: 1.5,
-        stroke: selected ? COLOR.ARROW_SELECTED : color,
+        stroke: selected ? COLOR.ARROW_SELECTED : highlighted ? COLOR.ARROW_HIGHLIGHTED : COLOR.ARROW_MARKER,
         fill: 'none',
       }}
       strokeLinecap="round"


### PR DESCRIPTION
Resolves #41 

Adds an optional color prop to arrow markers to make it possible to change their color when edges are in a hover state